### PR TITLE
Move angular deps to peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,11 +34,11 @@
   },
   "homepage": "https://github.com/SortableJS/angular-sortablejs#readme",
   "dependencies": {
-    "@angular/core": "^2.0.0",
-    "@angular/forms": "^2.0.0",
     "sortablejs": "^1.4.2"
   },
   "devDependencies": {
+    "@angular/core": "^2.0.0",
+    "@angular/forms": "^2.0.0",
     "@angular/compiler": "^2.1.0",
     "@angular/compiler-cli": "^2.1.0",
     "@types/core-js": "^0.9.32",
@@ -50,6 +50,10 @@
     "rxjs": "^5.0.2",
     "tslint": "^3.13.0",
     "typescript": "2.0.3"
+  },
+  "peerDependencies": {
+    "@angular/core": "^2.0.0",
+    "@angular/forms": "^2.0.0"
   },
   "files": [
     "dist/"


### PR DESCRIPTION
By including angular/core and angular/forms in the dependency list, and by not locking down the version, you can create angular compiler conflicts as two versions of angular can be installed into a project's node_modules. For example, I have a project locked to 2.4.5, which was working fine until this morning when I did a fresh npm install. It set up the following because of an angular update released on Friday.

- node_modules
  - @angular@2.4.5 <-- from project
  - angular-sortable
    - node_modules
      - @angular@2.4.6 <-- from sortable

All that's truly required is a peer dependency listing, any app consuming this library will have angular installed. I also added it to devDeps so that tests will continue to work.