### PR TITLE
should import from package sortablejs directly

### DIFF
--- a/src/sortablejs.directive.ts
+++ b/src/sortablejs.directive.ts
@@ -6,7 +6,7 @@ import { SortablejsOptions } from './sortablejs-options';
 import { GLOBALS } from './globals';
 import { SortablejsService } from './sortablejs.service';
 
-import * as Sortable from 'sortablejs/Sortable.min';
+import * as Sortable from 'sortablejs';
 
 @Directive({
   selector: '[sortablejs]'


### PR DESCRIPTION
Deep importing a specific file, a minified one in this case, makes debugging harder. Let the bundler tool handle minification.