### PR TITLE
Fix for issue #47 - cloning item on pull

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
   },
   "peerDependencies": {
     "sortablejs": ">=1.5.1",
-    "@angular/core": ">=4.0.0"
+    "@angular/core": ">=4.0.0",
+    "lodash": ">=4.17.0"
   },
   "files": [
     "dist/"

--- a/src/sortablejs-binding.ts
+++ b/src/sortablejs-binding.ts
@@ -25,6 +25,17 @@ export class SortablejsBinding {
     return item;
   }
 
+  at(index: number) {
+    let item;
+    if (this.isFormArray) {
+      item = this.target.at(index);
+    } else {
+      item = this.target[index];
+    }
+
+    return item;
+  }
+
   // we need this to identify that the target is a FormArray
   // we don't want to have a dependency on @angular/forms just for that
   private get isFormArray() {

--- a/src/sortablejs-bindings.ts
+++ b/src/sortablejs-bindings.ts
@@ -17,6 +17,10 @@ export class SortablejsBindings {
     return this.bindings.map(b => b.remove(index));
   }
 
+  getFromEvery(index: number) {
+    return this.bindings.map(b => b.at(index));
+  }
+
   get provided() {
     return !!this.bindings.length;
   }


### PR DESCRIPTION
If data bindings are provided, the items in the provided array has to be cloned manually as sortablejs is not aware of them.