### PR TITLE
Update sortablejs.directive.ts, rebinding overriten events

### DIFF
--- a/src/sortablejs.directive.ts
+++ b/src/sortablejs.directive.ts
@@ -66,7 +66,7 @@ export class SortablejsDirective implements OnInit, OnChanges, OnDestroy {
       Object.keys(currentOptions).forEach(optionName => {
         if (currentOptions[optionName] !== previousOptions[optionName]) {
           // use low-level option setter
-          this._sortable.option(optionName, currentOptions[optionName]);
+          this._sortable.option(optionName, this.options[optionName]);
         }
       });
     }


### PR DESCRIPTION
Update options with binded/overrided events like onUpdate.
There was problem when we update onUpdate options on fly, onUpdate was rejected and replaced fully with that from imput options, but we always want to do update on list of items.

this.options already contain in ngOnChanges new data from this.inputOptions and overridenOptions()