### PR TITLE
add new option

### DIFF
--- a/src/sortablejs-options.ts
+++ b/src/sortablejs-options.ts
@@ -7,6 +7,7 @@ export interface SortablejsOptions {
   };
   sort?: boolean;
   delay?: number;
+  touchStartThreshold?: number;
   disabled?: boolean;
   store?: {
     get: (sortable: any) => any[];


### PR DESCRIPTION
touchStartThreshold option
This option is similar to fallbackTolerance option.

When the delay option is set, some phones with very sensitive touch displays like the Samsung Galaxy S8 will fire unwanted touchmove events even when your finger is not moving, resulting in the sort not triggering.

This option sets the minimum pointer movement that must occur before the delayed sorting is cancelled.

Values between 3 to 5 are good.