### PR TITLE
add threshold options to interface

### DIFF
--- a/src/sortablejs-options.ts
+++ b/src/sortablejs-options.ts
@@ -20,6 +20,10 @@ export interface SortablejsOptions {
   ghostClass?: string;
   chosenClass?: string;
   dataIdAttr?: string;
+  swapThreshold?: number;
+  invertSwap?: boolean;
+  invertedSwapThreshold?: number;
+  direction?: string;
   forceFallback?: boolean;
   fallbackClass?: string;
   fallbackOnBody?: boolean;


### PR DESCRIPTION
As requested in issue #147 i added the threshold options to the interface.

```
swapThreshold // Threshold of the swap zone
invertSwap // Will always use inverted swap zone if set to true
invertedSwapThreshold // Threshold of the inverted swap zone (will be set to swapThreshold value by default)
direction // Direction of Sortable (will be detected automatically if not given)
```

Documentation: https://github.com/SortableJS/Sortable#swapthreshold-option 
Wiki: https://github.com/SortableJS/Sortable/wiki/Swap-Thresholds-and-Direction