### PR TITLE
Restricted ngOnChanges to only run when able

### DIFF
--- a/projects/ngx-sortablejs/src/lib/sortablejs.directive.ts
+++ b/projects/ngx-sortablejs/src/lib/sortablejs.directive.ts
@@ -64,7 +64,7 @@ export class SortablejsDirective implements OnInit, OnChanges, OnDestroy {
   ngOnChanges(changes: { [prop in keyof SortablejsDirective]: SimpleChange }) {
     const optionsChange: SimpleChange = changes.sortablejsOptions;
 
-    if (optionsChange && !optionsChange.isFirstChange()) {
+    if (this.sortableInstance && optionsChange && !optionsChange.isFirstChange()) {
       const previousOptions: SortablejsOptions = optionsChange.previousValue;
       const currentOptions: SortablejsOptions = optionsChange.currentValue;
 


### PR DESCRIPTION
Fixes: #172

Added condition that the sortableInstance has already been instantiated, before it can be used in the ngOnChanges method. Should resolve the error from this issue where ngOnChanges executes and breaks before sortableInstance actually exists.

I didn't see a CONTRIBUTING.md or any contribution information in the README, so please let me know if this is at all welcome and if there's anything else you need me to update such as the version in package.json/package-lock.json (is 0, so I assume no) or the changelog.